### PR TITLE
FEATURE: Allow 'reconnect' for LTI logins

### DIFF
--- a/assets/javascripts/discourse-lti/api-initializers/hide-lti-login-button.js
+++ b/assets/javascripts/discourse-lti/api-initializers/hide-lti-login-button.js
@@ -1,11 +1,22 @@
 import { apiInitializer } from "discourse/lib/api";
 import discourseComputed from "discourse-common/utils/decorators";
+import { findAll } from "discourse/models/login-method";
 
 export default apiInitializer("0.8", (api) => {
+  // LTI login must be initiated by the IdP
+  // Hide the LTI login button on the client side:
   api.modifyClass("component:login-buttons", {
     @discourseComputed
     buttons() {
       return this._super().filter((m) => m.name !== "lti");
     },
   });
+
+  // Connection is possible, but cannot be initiated
+  // by Discourse. It must be initiated by the IdP.
+  // Hide the button to avoid confusion:
+  const lti = findAll().find((p) => p.name === "lti");
+  if (lti) {
+    lti.can_connect = false;
+  }
 });

--- a/lib/discourse_lti/lti_authenticator.rb
+++ b/lib/discourse_lti/lti_authenticator.rb
@@ -10,9 +10,9 @@ class ::DiscourseLti::LtiAuthenticator < Auth::ManagedAuthenticator
   end
 
   def can_connect_existing_user?
-    # Impossible - LTI authentication can only be initiated
-    # by the identity provider
-    false
+    # Connection is possible, but must be initiated by the IdP.
+    # Discourse's "connect" button is hidden using javascript.
+    true
   end
 
   def enabled?

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -227,5 +227,15 @@ describe 'LTI Plugin' do
         expect(response.location).to include('/t/123')
       end
     end
+
+    context 'when a user is already logged in' do
+      before { sign_in Fabricate(:user) }
+
+      it 'automatically goes into auth_reconnect mode' do
+        post '/auth/lti/callback', params: callback_params.merge(samesite: 'true')
+        expect(response.status).to eq(302)
+        expect(response.location).to include('/associate/')
+      end
+    end
   end
 end


### PR DESCRIPTION
- enable the `can_connect_existing_user?`  boolean in the Authenticator
- patch the OmniauthCallbacksController to automatically enter reconnect mode for LTI
- hide the button on the preferences page, it must be initiated by the IdP