### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/assets/javascripts/discourse-lti/api-initializers/hide-lti-login-button.js
+++ b/assets/javascripts/discourse-lti/api-initializers/hide-lti-login-button.js
@@ -5,14 +5,16 @@ import { findAll } from "discourse/models/login-method";
 export default apiInitializer("0.8", (api) => {
   // LTI login must be initiated by the IdP
   // Hide the LTI login button on the client side:
-  api.modifyClass("component:login-buttons", {
-    pluginId: "discourse-lti",
-
-    @discourseComputed
-    buttons() {
-      return this._super().filter((m) => m.name !== "lti");
-    },
-  });
+  api.modifyClass(
+    "component:login-buttons",
+    (Superclass) =>
+      class extends Superclass {
+        @discourseComputed
+        buttons() {
+          return super.buttons().filter((m) => m.name !== "lti");
+        }
+      }
+  );
 
   // Connection is possible, but cannot be initiated
   // by Discourse. It must be initiated by the IdP.


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely