### PR TITLE
FIX: add Content-Type header to explicit tell the browser to parse the resubmitted auth response as HTML

### DIFF
--- a/lib/discourse_lti/lti_omniauth_strategy.rb
+++ b/lib/discourse_lti/lti_omniauth_strategy.rb
@@ -191,7 +191,7 @@ class DiscourseLti::LtiOmniauthStrategy
         end
         .join("\n")
 
-    response_headers = {}
+    response_headers = { "Content-Type" => "text/html; charset=UTF-8" }
 
     script_path = "/plugins/discourse-lti/javascripts/submit-on-load-lti.js"
     html = <<~HTML

--- a/spec/requests/lti_spec.rb
+++ b/spec/requests/lti_spec.rb
@@ -54,6 +54,7 @@ describe "LTI Plugin" do
       # will be sent by the browser
       post "/auth/lti/initiate", params: init_params
       expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("text/html; charset=UTF-8")
       expect(response.body).to include '<form method="post">',
               "<input type='hidden' name='samesite' value='true'/>",
               "<input type='hidden' name='iss' value='#{Rack::Utils.escape_html(platform_issuer_id)}'/>",
@@ -125,6 +126,7 @@ describe "LTI Plugin" do
     it "converts cross-site POST to same-site POST" do
       post "/auth/lti/callback", params: callback_params
       expect(response.status).to eq(200)
+      expect(response.headers["Content-Type"]).to eq("text/html; charset=UTF-8")
       expect(response.body).to include '<form method="post">',
               "<input type='hidden' name='samesite' value='true'/>",
               "<input type='hidden' name='id_token' value='#{Rack::Utils.escape_html(id_token)}'/>",


### PR DESCRIPTION
This plugin fails due to the `nosniff` header value added by https://github.com/discourse/discourse/pull/31619, which causes the omniauth resubmitted response to be interpreted by the browser as plain text instead of HTML.

This change adds that `Content-Type` header with the correct html value.

